### PR TITLE
Bug fix 'Model Xxxxxx.php not found' when table contains underscore a…

### DIFF
--- a/src/Models/TableMigration.php
+++ b/src/Models/TableMigration.php
@@ -517,7 +517,7 @@ class TableMigration implements Countable
 
             $modelNames = [];
             foreach (explode('_', $tableName) as $word) {
-                $modelNames[] = Inflector::singularize($word);
+                $modelNames[] = ucfirst(Inflector::singularize($word));
             } //foreach
             $modelName = implode('', $modelNames);
 


### PR DESCRIPTION
…nd consists of two words like order_items -> OrderItems.php ( was Orderitems.php)
